### PR TITLE
mars rover added

### DIFF
--- a/'
+++ b/'
@@ -1,0 +1,89 @@
+package nasa
+
+import (
+	"net/http"
+	"os"
+	"sync"
+)
+
+var (
+	apiKey = os.Getenv("NASA_API_KEY")
+)
+
+type Client struct {
+	apiKey  string
+	version string
+	mu      sync.RWMutex
+}
+
+func (c *Client) SetAPIKey(apiKey string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.apiKey = apiKey
+}
+
+func (c *Client) SetVersion(version string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.v = version
+}
+
+func (c *Client) Version() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+}
+
+func (c *Client) APIKey() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.apiKey
+}
+
+type MarsPhoto struct {
+	Id     int     `json:"id"`
+	SOL    int     `json:"sol"`
+	Camera *Camera `json:"camera,omitempty"`
+	Rover  *Rover  `json:"rover,omitempty"`
+}
+
+type Camera struct {
+	Id        int        `json:"id,omitempty"`
+	ShortName string     `json:"name,omitempty"`
+	RoverId   int        `json:"rover_id,omitempty"`
+	FullName  string     `json:"full_name,omitempty"`
+	EarthDate *time.Time `json:"earth_date,omitempty"`
+}
+
+type Rover struct {
+	Id      int        `json:"id"`
+	Name    string     `json:"name"`
+	MaxSOL  int        `json:"max_sol"`
+	MaxDate *time.Time `json:"max_date"`
+	Status  Status     `json:"status"`
+	Cameras []*Camera  `json:"camera"`
+
+	LandingDate *time.Time `json:"landing_date"`
+	LaunchDate  *time.Time `json:"launch_date"`
+	TotalPhotos uint64     `json:"total_photos"`
+}
+
+func (c *Client) queryParamsForPhotos(earthDate *time.Time, apiKey string) string {
+	if earthDate == nil {
+		now = time.Now()
+		earthDate = &now
+	}
+	args := []string{fmt.Sprintf("earth_date=%v-%v-%v", t.Year(), t.Month(), t.Day())}
+	if apiKey := c.APIKey(); apiKey != "" {
+		args = append(args, fmt.Spritnf("api_key=%s", apiKey))
+	}
+
+	return strings.Join(args, "&")
+}
+
+func (c *Client) MarsPhotos(t time.Time) ([]*MarsPhoto, error) {
+	// https://api.nasa.gov/mars-photos/api/v1/rovers/curiosity/photos?earth_date=2016-10-23&api_key=DEMO_KEY
+	res, err := http.Get()
+}

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# Text editor files
+*.sw[op]

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,42 @@
+package nasa_test
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/odeke-em/nasa"
+)
+
+func Example_clientMarsPhotoTody() {
+	client, err := nasa.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	marsPhotos, err := client.MarsPhotosToday()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for i, photo := range marsPhotos.Photos {
+		fmt.Printf("#%d: id:%d earthDate: %s imageURL: %s\n", i, photo.Id, photo.EarthDate, photo.ImageURL)
+	}
+}
+
+func Example_clientMarsPhoto() {
+	client, err := nasa.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	tenHoursAgo := time.Now().Add(-10 * time.Hour)
+	marsPhotos, err := client.MarsPhotos(&tenHoursAgo)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for i, photo := range marsPhotos.Photos {
+		fmt.Printf("#%d: id:%d earthDate: %s imageURL: %s\n", i, photo.Id, photo.EarthDate, photo.ImageURL)
+	}
+}

--- a/nasa.go
+++ b/nasa.go
@@ -1,0 +1,257 @@
+package nasa
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	defaultAPIVersion = "v1"
+
+	apiBaseURL = "https://api.nasa.gov"
+
+	defaultUserAgent = "go-nasa-fetcher"
+)
+
+var (
+	apiKey = os.Getenv("NASA_API_KEY")
+
+	defaultAPIKey = "DEMO_KEY"
+)
+
+type Client struct {
+	apiKey    string
+	version   string
+	client    *http.Client
+	userAgent string
+	mu        sync.RWMutex
+}
+
+func (c *Client) SetAPIKey(apiKey string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.apiKey = apiKey
+}
+
+func (c *Client) SetVersion(version string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.version = version
+}
+
+func (c *Client) Version() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	version := c.version
+	if version == "" {
+		version = defaultAPIVersion
+	}
+	return version
+}
+
+func (c *Client) APIKey() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	apiKey := c.apiKey
+	if apiKey == "" {
+		apiKey = defaultAPIKey
+	}
+	return apiKey
+}
+
+type MarsPhotos struct {
+	Photos []*MarsPhoto `json:"photos,omitempty"`
+}
+
+type MarsPhoto struct {
+	Id        int      `json:"id"`
+	SOL       int      `json:"sol"`
+	Camera    *Camera  `json:"camera,omitempty"`
+	Rover     *Rover   `json:"rover,omitempty"`
+	EarthDate *YMDTime `json:"earth_date,omitempty"`
+	ImageURL  string   `json:"img_src,omitempty"`
+}
+
+type YMDTime time.Time
+
+func (ymd *YMDTime) UnmarshalJSON(b []byte) error {
+	var str string
+	if err := json.Unmarshal(b, &str); err != nil {
+		return err
+	}
+	splits := strings.Split(str, "-")
+	if len(splits) < 3 {
+		return fmt.Errorf("expecting atleast 3 values separated by -, got %q", str)
+	}
+	values := []int{}
+	for _, split := range splits {
+		v, err := strconv.ParseInt(split, 10, 32)
+		if err != nil {
+			return err
+		}
+		values = append(values, int(v))
+	}
+
+	*ymd = YMDTime(time.Date(values[0], time.Month(values[1]), values[2], 0, 0, 0, 0, time.UTC))
+	return nil
+}
+
+func (ymd YMDTime) String() string {
+	year, month, day := time.Time(ymd).Date()
+	return fmt.Sprintf("%d-%d-%d", year, month, day)
+}
+
+func (ymd *YMDTime) MarshalJSON() ([]byte, error) {
+	return []byte(ymd.String()), nil
+}
+
+type Camera struct {
+	Id        int      `json:"id,omitempty"`
+	ShortName string   `json:"name,omitempty"`
+	RoverId   int      `json:"rover_id,omitempty"`
+	FullName  string   `json:"full_name,omitempty"`
+	EarthDate *YMDTime `json:"earth_date,omitempty"`
+}
+
+type Rover struct {
+	Id      int       `json:"id"`
+	Name    string    `json:"name"`
+	MaxSOL  int       `json:"max_sol"`
+	MaxDate *YMDTime  `json:"max_date"`
+	Status  Status    `json:"status"`
+	Cameras []*Camera `json:"camera"`
+
+	LandingDate *YMDTime `json:"landing_date"`
+	LaunchDate  *YMDTime `json:"launch_date"`
+	TotalPhotos uint64   `json:"total_photos"`
+}
+
+func (c *Client) queryParamsForPhotos(earthDate *time.Time) string {
+	if earthDate == nil {
+		now := time.Now()
+		earthDate = &now
+	}
+	ymd := YMDTime(*earthDate)
+	args := []string{fmt.Sprintf("earth_date=%s", ymd)}
+	if apiKey := c.APIKey(); apiKey != "" {
+		args = append(args, fmt.Sprintf("api_key=%s", apiKey))
+	}
+
+	return strings.Join(args, "&")
+}
+
+type Option interface {
+	Apply(*Client)
+}
+
+type WithAPIKey string
+
+func (key WithAPIKey) Apply(c *Client) {
+	c.SetAPIKey(string(key))
+}
+
+type WithHTTPClient struct {
+	Client *http.Client
+}
+
+func (whc WithHTTPClient) Apply(c *Client) {
+	c.client = whc.Client
+}
+
+func New(options ...Option) (*Client, error) {
+	c := new(Client)
+	for _, opt := range options {
+		opt.Apply(c)
+	}
+	return c, nil
+}
+
+type WithUserAgent string
+
+func (wua WithUserAgent) Apply(c *Client) {
+	c.userAgent = string(wua)
+}
+
+type requestDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+func (c *Client) UserAgent() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	ua := c.userAgent
+	if ua == "" {
+		ua = defaultUserAgent
+	}
+	return ua
+}
+
+func (c *Client) SetUserAgent(ua string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.userAgent = ua
+}
+
+func (c *Client) httpClient() requestDoer {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.client == nil {
+		return http.DefaultClient
+	}
+	return c.client
+}
+
+func (c *Client) MarsPhotosToday() (*MarsPhotos, error) {
+	return c.MarsPhotos(nil)
+}
+
+func (c *Client) MarsPhotos(t *time.Time) (*MarsPhotos, error) {
+	// https://api.nasa.gov/mars-photos/api/v1/rovers/curiosity/photos?earth_date=2016-10-23&api_key=DEMO_KEY
+	// https://api.nasa.gov/mars-photos/api/v1/rovers/curiosity/photos?earth_date=2014-10-25&api_key=DEMO_KEY
+	path := fmt.Sprintf("%s/rovers/curiosity/photos", c.Version())
+	if queryParamsStr := c.queryParamsForPhotos(t); queryParamsStr != "" {
+		path = fmt.Sprintf("%s?%s", path, queryParamsStr)
+	}
+
+	apiURL := fmt.Sprintf("%s/mars-photos/api/%s", apiBaseURL, path)
+	log.Printf("apiURL: %q\n", apiURL)
+	req, _ := http.NewRequest("GET", apiURL, nil)
+	req.Header.Add("User-Agent", c.UserAgent())
+
+	res, err := c.httpClient().Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode < 200 || res.StatusCode > 299 {
+		return nil, fmt.Errorf("%d %s", res.StatusCode, res.Status)
+	}
+
+	blob, err := ioutil.ReadAll(res.Body)
+	_ = res.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	marsPhotos := new(MarsPhotos)
+	if err := json.Unmarshal(blob, marsPhotos); err != nil {
+		return nil, err
+	}
+
+	return marsPhotos, nil
+}

--- a/status.go
+++ b/status.go
@@ -1,0 +1,35 @@
+package nasa
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+type Status string
+
+const (
+	Active   Status = "active"
+	Inactive Status = "inactive"
+)
+
+func (s Status) String() string {
+	return string(s)
+}
+
+func (s *Status) UnmarshalJSON(b []byte) error {
+	var str string
+	if err := json.Unmarshal(b, &str); err != nil {
+		return err
+	}
+	switch strings.ToLower(str) {
+	default:
+		*s = Inactive
+	case "active":
+		*s = Active
+	}
+	return nil
+}
+
+func (s Status) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(s))
+}

--- a/testdata/mars-rover-2016-10-23.json
+++ b/testdata/mars-rover-2016-10-23.json
@@ -1,0 +1,44 @@
+{
+  id: 593504,
+  sol: 1498,
+  camera: {
+    id: 26,
+    name: "NAVCAM",
+    rover_id: 5,
+    full_name: "Navigation Camera"
+  },
+  img_src: "http://mars.jpl.nasa.gov/msl-raw-images/proj/msl/redops/ods/surface/sol/01498/opgs/edr/ncam/NLB_530462131EDR_F0582046NCAM00206M_.JPG",
+  earth_date: "2016-10-23",
+  rover: {
+    id: 5,
+    name: "Curiosity",
+    landing_date: "2012-08-06",
+    launch_date: "2011-11-26",
+    status: "active",
+    max_sol: 1498,
+    max_date: "2016-10-23",
+    total_photos: 284387,
+    cameras: [{
+      name: "FHAZ",
+      full_name: "Front Hazard Avoidance Camera"
+    }, {
+      name: "NAVCAM",
+      full_name: "Navigation Camera"
+    }, {
+      name: "MAST",
+      full_name: "Mast Camera"
+    }, {
+      name: "CHEMCAM",
+      full_name: "Chemistry and Camera Complex"
+    }, {
+      name: "MAHLI",
+      full_name: "Mars Hand Lens Imager"
+    }, {
+      name: "MARDI",
+      full_name: "Mars Descent Imager"
+    }, {
+      name: "RHAZ",
+      full_name: "Rear Hazard Avoidance Camera"
+    }]
+  }
+}


### PR DESCRIPTION
Added Mars Rover api client and an example
- Exhibits:
  #0: id:593504 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/proj/msl/redops/ods/surface/sol/01498/opgs/edr/ncam/NLB_530462131EDR_F0582046NCAM00206M_.JPG
  #1: id:593505 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/proj/msl/redops/ods/surface/sol/01498/opgs/edr/ccam/CR0_530485970EDR_F0582046CCAM07497M_.JPG
  #2: id:593506 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/proj/msl/redops/ods/surface/sol/01498/opgs/edr/ccam/CR0_530485447EDR_F0582046CCAM07497M_.JPG
  #3: id:593507 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/proj/msl/redops/ods/surface/sol/01498/opgs/edr/ccam/CR0_530485090EDR_F0582046CCAM07497M_.JPG
  #4: id:593508 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/proj/msl/redops/ods/surface/sol/01498/opgs/edr/ccam/CR0_530484745EDR_F0582046CCAM07497M_.JPG
  #5: id:593509 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/proj/msl/redops/ods/surface/sol/01498/opgs/edr/ccam/CR0_530474455EDR_F0582046CCAM06497M_.JPG
  #6: id:593510 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/proj/msl/redops/ods/surface/sol/01498/opgs/edr/ccam/CR0_530473710EDR_F0582046CCAM06497M_.JPG
  #7: id:593511 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/proj/msl/redops/ods/surface/sol/01498/opgs/edr/ccam/CR0_530473570EDR_F0582046CCAM05497M_.JPG
  #8: id:593512 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/proj/msl/redops/ods/surface/sol/01498/opgs/edr/ccam/CR0_530472834EDR_F0582046CCAM05497M_.JPG
  #9: id:593513 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/proj/msl/redops/ods/surface/sol/01498/opgs/edr/ccam/CR0_530472753EDR_F0582046CCAM04497M_.JPG
  #10: id:593514 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/proj/msl/redops/ods/surface/sol/01498/opgs/edr/ccam/CR0_530472448EDR_F0582046CCAM04497M_.JPG
  #11: id:593515 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/proj/msl/redops/ods/surface/sol/01498/soas/rdr/ccam/CR0_530485970PRC_F0582046CCAM07497L1.PNG
  #12: id:593516 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/proj/msl/redops/ods/surface/sol/01498/soas/rdr/ccam/CR0_530485447PRC_F0582046CCAM07497L1.PNG
  #13: id:593517 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/proj/msl/redops/ods/surface/sol/01498/soas/rdr/ccam/CR0_530485090PRC_F0582046CCAM07497L1.PNG
  #14: id:593518 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/proj/msl/redops/ods/surface/sol/01498/soas/rdr/ccam/CR0_530484745PRC_F0582046CCAM07497L1.PNG
  #15: id:593519 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/proj/msl/redops/ods/surface/sol/01498/soas/rdr/ccam/CR0_530474455PRC_F0582046CCAM06497L1.PNG
  #16: id:593520 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/proj/msl/redops/ods/surface/sol/01498/soas/rdr/ccam/CR0_530473710PRC_F0582046CCAM06497L1.PNG
  #17: id:593521 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/proj/msl/redops/ods/surface/sol/01498/soas/rdr/ccam/CR0_530473570PRC_F0582046CCAM05497L1.PNG
  #18: id:593522 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/msss/01498/mhli/1498MH0000930000504708C00_DXXX.jpg
  #19: id:593523 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/msss/01498/mhli/1498MH0000950010504707C00_DXXX.jpg
  #20: id:593524 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/msss/01498/mhli/1498MH0005530010504705C00_DXXX.jpg
  #21: id:593525 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/msss/01498/mhli/1498MH0004530050504723I01_DXXX.jpg
  #22: id:593526 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/msss/01498/mhli/1498MH0004530040504722I01_DXXX.jpg
  #23: id:593527 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/msss/01498/mhli/1498MH0004530030504721I01_DXXX.jpg
  #24: id:593528 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/msss/01498/mhli/1498MH0004530020504720I01_DXXX.jpg
  #25: id:593529 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/msss/01498/mhli/1498MH0004530010504719I01_DXXX.jpg
  #26: id:593530 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/msss/01498/mhli/1498MH0004530000504718I01_DXXX.jpg
  #27: id:593531 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/msss/01498/mhli/1498MH0000930010504717I01_DXXX.jpg
  #28: id:593532 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/msss/01498/mhli/1498MH0000930000504716I01_DXXX.jpg
  #29: id:593533 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/msss/01498/mhli/1498MH0004530050504715I01_DXXX.jpg
  #30: id:593534 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/msss/01498/mhli/1498MH0004530040504714I01_DXXX.jpg
  #31: id:593535 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/msss/01498/mhli/1498MH0004530030504713I01_DXXX.jpg
  #32: id:593536 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/msss/01498/mhli/1498MH0004530020504712I01_DXXX.jpg
  #33: id:593537 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/msss/01498/mhli/1498MH0004530010504711I01_DXXX.jpg
  #34: id:593538 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/msss/01498/mhli/1498MH0004530000504710I01_DXXX.jpg
  #35: id:593539 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/msss/01498/mhli/1498MH0000930010504709I01_DXXX.jpg
  #36: id:593540 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/msss/01498/mhli/1498MH0000930000504708I01_DXXX.jpg
  #37: id:593541 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/msss/01498/mhli/1498MH0000950010504707I01_DXXX.jpg
  #38: id:593542 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/msss/01498/mhli/1498MH0000950000504706I01_DXXX.jpg
  #39: id:593543 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/msss/01498/mhli/1498MH0005530010504705I01_DXXX.jpg
  #40: id:593544 earthDate: 2016-10-23 imageURL:
  http://mars.jpl.nasa.gov/msl-raw-images/msss/01498/mhli/1498MH0005530000504704I01_DXXX.jpg

![](http://mars.jpl.nasa.gov/msl-raw-images/msss/01498/mhli/1498MH0005530000504704I01_DXXX.jpg)
![](http://mars.jpl.nasa.gov/msl-raw-images/msss/01498/mhli/1498MH0005530010504705I01_DXXX.jpg)
![](http://mars.jpl.nasa.gov/msl-raw-images/proj/msl/redops/ods/surface/sol/01498/opgs/edr/ncam/NLB_530462131EDR_F0582046NCAM00206M_.JPG)
![](http://mars.jpl.nasa.gov/msl-raw-images/proj/msl/redops/ods/surface/sol/01498/opgs/edr/ccam/CR0_530472753EDR_F0582046CCAM04497M_.JPG)
